### PR TITLE
configure.ac: remove `-flat_namespace` usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ AC_SUBST(HAIKU)
 target=`$CC -dumpmachine`
 AS_CASE([$target],
 	[*-darwin*],[
-		SHARED_FLAGS="-dynamiclib -flat_namespace -undefined suppress"
+		SHARED_FLAGS="-dynamiclib -undefined dynamic_lookup"
 		CFLAGS="$CFLAGS -fno-common"
 		CXXFLAGS="$CXXFLAGS -fno-common"
 		LIB_SUFFIX=.dylib


### PR DESCRIPTION
Apple discourages the use of `-flat_namespace`, and the only reason it continues to exist is for compatibility with very old versions of OS X. Unless the program being built specifically requires the benefits of a flat namespace, it is best to avoid the flag to prevent linker errors, e.g. due to name collisions, as discussed [here](https://developer.apple.com/forums/thread/689991). (Note: An Apple staff member mentions that the flag is effectively deprecated.)

This PR aims to fix the flat namespace audit failure at Homebrew/homebrew-core#95769.