### PR TITLE
XDG Base Directory compliance.

### DIFF
--- a/boot/kickload.c
+++ b/boot/kickload.c
@@ -376,7 +376,7 @@ int validate_home(void)
 		home="/root";
 	else if (!strlen(home)) 
 	{
-		fprintf(stderr, "Either $HOME or $XDG_CONFIG_HOME is defined with a zero length variable. Please correctly define the specified path or unset the erroronous variable.\n");
+		fprintf(stderr, "Either $HOME or $XDG_CONFIG_HOME is defined with a zero length variable. Please correctly define the specified path or unset the erroneous variable.\n");
 		return -1;
 	}
 	else if ((*home)!='/')

--- a/boot/kickload.c
+++ b/boot/kickload.c
@@ -365,15 +365,20 @@ static int cp(const char *src, const char *dst)
 
 int validate_home(void)
 {
-	const char *home=getenv("HOME");
+	const char *xdg = getenv("XDG_CONFIG_HOME");
+	const char *homeEnv = getenv("HOME");
+	const char *home = xdg ? xdg : homeEnv;
 	char *temp;
 	const char *temp2;
 	struct stat st;
 
 	if (!home)
 		home="/root";
-	else if (!strlen(home))
-		home="/root";
+	else if (!strlen(home)) 
+	{
+		fprintf(stderr, "Either $HOME or $XDG_CONFIG_HOME is defined with a zero length variable. Please correctly define the specified path or unset the erroronous variable.\n");
+		return -1;
+	}
 	else if ((*home)!='/')
 	{
 		fprintf(stderr, "$HOME does not start with a /\n");
@@ -383,7 +388,7 @@ int validate_home(void)
 	strcpy(temp, home);
 	if (temp[strlen(temp)-1]!='/')
 		strcat(temp, "/");
-	strcat(temp, ".ocp/");
+	strcat(temp, xdg ? "ocp/" : ".ocp/");
 
 #ifdef __HAIKU__
 	{

--- a/boot/pmain.c
+++ b/boot/pmain.c
@@ -901,9 +901,9 @@ static int init_modules(int argc, char *argv[])
 			cfStoreConfig();
 			if (isatty(2))
 			{
-				fprintf(stderr,"\n\033[1m\033[31mWARNING, ocp.ini has changed, have tried my best to update it. If OCP failes to start, please try to remove by doing this:\033[0m\nrm -f ~/.ocp/ocp.ini\n\n");
+				fprintf(stderr,"\n\033[1m\033[31mWARNING, ocp.ini has changed, have tried my best to update it. If OCP failes to start, please try to remove by doing either:\033[0m\nrm -f ~/.ocp/ocp.ini\033[1m\033[31m or \033[0m\nrm -f $XDG_CONFIG_HOME/ocp/ocp.ini\n\n");
 			} else {
-				fprintf(stderr,"\nWARNING, ocp.ini has changed, have tried my best to update it. If OCP failes to start, please try to remove by doing this:\nrm -f ~/.ocp/ocp.ini\n\n");
+				fprintf(stderr,"\nWARNING, ocp.ini has changed, have tried my best to update it. If OCP failes to start, please try to remove by doing either:\nrm -f ~/.ocp/ocp.ini or rm -f $XDG_CONFIG_HOME/ocp/ocp.ini\n\n");
 			}
 			sleep(5);
 		}

--- a/boot/psetting.c
+++ b/boot/psetting.c
@@ -644,7 +644,7 @@ int cfGetConfig(int argc, char *argv[])
 		return -1; /* no config at all pigs! */
 	if (cfReadINIFile(argc, argv))
 	{
-		fprintf(stderr, "Failed to read ocp.ini\nPlease put it in ~/.ocp/\n");
+		fprintf(stderr, "Failed to read ocp.ini\nPlease put it in ~/.ocp/ or $XDG_CONFIG_HOME/ocp/\n");
 		return -1;
 	}
 


### PR DESCRIPTION
This commit introduces basic XDG Base Directory Specification compliance, and a bug fix disallowing blank environmental variables.

OCP successfully loads and creates the ocp.ini configuration file in `$XDG_CONFIG_HOME/ocp/ocp.ini`, otherwise it falls back to `$HOME/.ocp/ocp.ini` if the `$XDG_CONFIG_HOME` environmental variable is missing.

Sample output with `$XDG_CONFIG_HOME` globally defined:
```$ ocp -Dcurses
/home/sapphirus/.config/ocp/ocp.ini created
Setting to cfConfigDir to /home/sapphirus/.config/ocp/
Setting to cfDataDir to /usr/share/ocp/data/
Setting to cfProgramDir to /usr/lib/ocp/
Open Cubic Player for Unix v0.2.101, compiled on Jan 12 2023, 13:53:25
Ported to Unix by Stian Skjelstad
linking default objects...
running initializers...
initializing fileselector...
adbMetaInit: open(cfConfigDir/CPARCMETA.DAT): No such file or directory
Loading /home/sapphirus/.config/ocp/CPMODNFO.DAT .. No header
open(cfConfigDir/CPDIRDB.DAT): No such file or directory
Loading /home/sapphirus/.config/ocp/CPMUSBRN.DAT .. Empty database
Initing console...
Initing curses... (ncurses 6.4.20221231)
```
Sample output with `$XDG_CONFIG_HOME` unset:
```[sapphirus@workstation boot]$ env --unset XDG_CONFIG_HOME ocp -Dcurses
Setting to cfConfigDir to /home/sapphirus/.ocp/
Setting to cfDataDir to /usr/share/ocp/data/
Setting to cfProgramDir to /usr/lib/ocp/
Open Cubic Player for Unix v0.2.101, compiled on Jan 12 2023, 14:48:48
Ported to Unix by Stian Skjelstad
linking default objects...
running initializers...
initializing fileselector...
adbMetaInit: open(cfConfigDir/CPARCMETA.DAT): No such file or directory
Loading /home/sapphirus/.ocp/CPMODNFO.DAT .. Done
open(cfConfigDir/CPDIRDB.DAT): No such file or directory
Loading /home/sapphirus/.ocp/CPMUSBRN.DAT .. Empty database
Initing console...
Initing curses... (ncurses 6.4.20221231)
```

Sample output with  `XDG_CONFIG_HOME` or `$HOME` defined blank:
```
$ env | grep XDG_CONFIG_HOME
XDG_CONFIG_HOME=
$ ocp -Dcurses
Either $HOME or $XDG_CONFIG_HOME is defined with a zero length variable. Please correctly define the specified path or unset the erroneous variable.
```