### PR TITLE
Fix screen configuration documentation

### DIFF
--- a/doc/opencp.dox.in
+++ b/doc/opencp.dox.in
@@ -1637,19 +1637,22 @@ appearance.
   ~analyzer~         if the player starts in textmode show the analyzer (or not)
   ~mvoltype~         the appearance of the peak power levels:
 
+                     ~0~  none
                      ~1~  big
                      ~2~  small
   ~pattern~          show the tracklist when starting OCP in textmode
   ~insttype~         the appearance of the instrument function:
 
-                     ~0~  short
-                     ~1~  long
-                     ~2~  side (only in 132 column modes)
+                     ~0~  none
+                     ~1~  short
+                     ~2~  long
+                     ~3~  side (only in 132 column modes)
   ~channeltype~      the appearance of the channels in textmode:
 
-                     ~0~  short
-                     ~1~  long
-                     ~2~  side (only in 132 column modes)
+                     ~0~  none
+                     ~1~  short
+                     ~2~  long
+                     ~3~  side (only in 132 column modes)
   ~palette~          with this option you can redefine the default colours used
                      in textmode. The first entry defines which colour to use
                      for the original colour with number 0. Leave things as they

--- a/doc/texi/configuration.texi
+++ b/doc/texi/configuration.texi
@@ -310,6 +310,7 @@ if the player starts in textmode show the analyzer (or not)
 @item mvoltype @tab
 the appearance of the peak power levels:
 @itemize
+@item 0 - none
 @item 1 - big
 @item 2 - small
 @end itemize
@@ -318,16 +319,18 @@ show the tracklist when starting OCP in textmode
 @item insttype @tab
 the appearance of the instrument function:
 @itemize
-@item 0 - short
-@item 1 - long
-@item 2 - side (only in 132 column modes)
+@item 0 - none
+@item 1 - short
+@item 2 - long
+@item 3 - side (only in 132 column modes)
 @end itemize
 @item channeltype @tab
 the appearance of the channels in textmode:
 @itemize
-@item 0 - short
-@item 1 - long
-@item 2 - side (only in 132 column mode)
+@item 0 - none
+@item 1 - short
+@item 2 - long
+@item 3 - side (only in 132 column mode)
 @end itemize
 @item palette @tab
 with this options you can redefine the default colors used in


### PR DESCRIPTION
When configuring ocp I noticed that the values for insttype and channeltype are wrong in the documentation. Also, to disable mvoltype was undocumented.

It looks like the insttype settings doesn't work any longer in v0.2.102 though, but they do in v0.2.101.