### PR TITLE
Fix build with clang10.0.1

### DIFF
--- a/devw/devwnone.c
+++ b/devw/devwnone.c
@@ -493,7 +493,7 @@ static const struct mcpDevAPI_t *devwNoneInit (const struct mcpDriver_t *driver)
 	return &devwNone;
 }
 
-static void devwNoneClose (const struct mcpDriver_t *)
+static void devwNoneClose (const struct mcpDriver_t *driver)
 {
 }
 


### PR DESCRIPTION
Some older still supported FreeBSD versions use clang 10.0.1. There it fails to build with:

```
cc -O2 -pipe  -DLIBICONV_PLUG -fstack-protector-strong -isystem /usr/local/include -fno-strict-aliasing  -fPIC -D_GNU_SOURCE  -Wall -I.././ -O devwnone.c -o devwnone.o -c
devwnone.c:496:54: error: parameter name omitted
static void devwNoneClose (const struct mcpDriver_t *)
                                                     ^
1 error generated.
```