### PR TITLE
fix: clockid_t redefinition patch for osx 10.12 and later

### DIFF
--- a/types.h
+++ b/types.h
@@ -87,7 +87,9 @@
 extern "C" {
 #  endif
 
+# if (__MAC_OS_X_VERSION_MAX_ALLOWED < 101200)
 typedef int clockid_t;
+# endif
 int clock_gettime(clockid_t clk_id, struct timespec *tp);
 
 #  ifdef __cplusplus


### PR DESCRIPTION
```
../types.h:90:13: error: typedef redefinition with different types ('int' vs 'enum clockid_t')
typedef int clockid_t;
            ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/time.h:172:3: note: previous definition is here
} clockid_t;
  ^
1 error generated.
```

relates to https://github.com/Homebrew/homebrew-core/pull/123669