### PR TITLE
Bring Quickhelp up to date

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -33,6 +33,7 @@ Ossi Saukko                                                   - Minor patch
 Nanda H Krishna                                               - Minor patch
 cysp74                                                        - Minor patch
 Miguel Vanhove aka redbug26                                   - Minor patch
+Håkan Jerning                                                 - Documentation updates
 
 
 Also, see AUTHORS file

--- a/cpiface/cpitext.c
+++ b/cpiface/cpitext.c
@@ -525,11 +525,11 @@ static int txtAProcessKey (struct cpifaceSessionAPI_t *cpifaceSession, uint16_t 
 		case KEY_ALT_K:
 			cpiKeyHelp('x', "Set screen text mode 160x128 (font 8x8)");
 			cpiKeyHelp('X', "Set screen text mode 160x128 (font 8x8)");
-			cpiKeyHelp('z', "Adjust screen text mode (toggle minor size)");
-			cpiKeyHelp('Z', "Adjust screen text mode (toggle minor size)");
+			cpiKeyHelp('z', "Adjust screen text mode (toggle font 8x8/8x16)");
+			cpiKeyHelp('Z', "Adjust screen text mode (toggle font 8x8/8x16)");
 			cpiKeyHelp(KEY_ALT_X, "Set screen text screen mode 80x25 (font 8x16)");
 			cpiKeyHelp(KEY_ALT_Z, "Adjust screen text screen mode (toggle major size)");
-			cpiKeyHelp(KEY_CTRL_Z, "Adjust screen text screen mode (toggle font 8x8/8x16)");
+			cpiKeyHelp(KEY_CTRL_Z, "Adjust screen text screen mode (toggle minor size)");
 			return 0;
 		case 'x': case 'X':
 			fsScrType=7;

--- a/doc/opencp.dox.in
+++ b/doc/opencp.dox.in
@@ -776,12 +776,12 @@ You can use all these keys throughout the player except in special modes.
 ctrl-^0f^07   : go 8 rows up                         ^0f^07, ^0f^07 : select previous channel
 ctrl-^0f^07   : go 8 rows down                       ^0f^07, ^0f^07 : select next channel
 ctrl-^0fhome^07: restart module                       ^0f1^07..^0f0^07 : goto and toggle channel
-
-  ^0f-^07 ^0fPlayer^07 ^0fKeys^07 ^0f-^07                                  ^0fq^07 : toggle selected channel
-    ^0freturn^07 : play next module                      ^0fs^07 : solo selected channel
-  (ctrl-)^0fp^07 : pause module (immediate)       ctrl-^0fq^07/^0fs^07 : turn on all channels
-         ^0fd^07 : open a shell                          ^0fc^07 : toggle channel mode
-   ^0fesc^07 ^0fesc^07 : e-s-c-a-p-e                               (none/short/long/side)
+                                                   ^0fq^07 : toggle selected channel
+  ^0f-^07 ^0fPlayer^07 ^0fKeys^07 ^0f-^07                                  ^0fs^07 : solo selected channel
+    ^0freturn^07 : play next module               ctrl-^0fq^07/^0fs^07 : turn on all channels
+  (ctrl-)^0fp^07 : pause module (immediate)              ^0fc^07 : toggle channel mode
+         ^0fd^07 : open a shell                              (none/short/long/side)
+   ^0fesc^07 ^0fesc^07 : e-s-c-a-p-e
     ^0fins^07, ^0ff^07 : file selector
          ^0fz^07 : tog. font (8x8/8x16)
     ctrl-^0fz^07 : tog. scr. minor

--- a/doc/opencp.dox.in
+++ b/doc/opencp.dox.in
@@ -778,7 +778,7 @@ ctrl-^0f^07   : go 8 rows down                       ^0f\d^07, ^0f^07 : select
 ctrl-^0fhome^07: restart module                       ^0f1^07..^0f0^07 : goto and toggle channel
                                            ctrl-^0f1^07..^0f0^07 : goto and solo channel
   ^0f-^07 ^0fPlayer^07 ^0fKeys^07 ^0f-^07                                  ^0fq^07 : toggle selected channel
-(c-)^0freturn^07 : play next module (fadeout)            ^0fs^07 : solo selected channl
+    ^0freturn^07 : play next module                      ^0fs^07 : solo selected channl
   (ctrl-)^0fp^07 : pause module (immediate)       ctrl-^0fq^07/^0fs^07 : turn on all channels
   (ctrl-)^0fd^07 : dos-shell (no reminder)               ^0fc^07 : toggle channel mode
    ^0fesc^07 ^0fesc^07 : e-s-c-a-p-e                               (none/short/long/side)

--- a/doc/opencp.dox.in
+++ b/doc/opencp.dox.in
@@ -852,7 +852,6 @@ ctrl-^0fpgup^07/^0fdn^07 - change analyser gain
      ^0fpgup^07/^0fdn^07 - change visible frequency range
         ^0fhome^07 - set maximum frequency to approximately 3000Hz
          ^0ftab^07 - set next palette
-     alt-^0ftab^07 - set previous palette
    shift-^0ftab^07 - set normal analysers palette
 
 ^0bScopes:^07  ^0b<o>^07

--- a/doc/opencp.dox.in
+++ b/doc/opencp.dox.in
@@ -759,40 +759,40 @@ You can use all these keys throughout the player except in special modes.
   ^0f-^07 ^0fMode^07 ^0fKeys^07 ^0f-^07                                 ^0f-^07 ^0fVolume^07 ^0fKeys^07 ^0f-^07
 ^0fi^07 : instruments                                     ^0fF1^07 : help
 ^0ft^07 : track view                                 ^0fF2^07 , ^0fF3^07 : change volume (^0f+^07,^0f-^07)
-^0fa^07 : textmode analyser                         c^0fF2^07 ,c^0fF3^07 : change amplification
+^0fa^07 : textmode analyser                         s^0fF2^07 ,s^0fF3^07 : change amplification
 ^0fx^07 : xtended mode (i,t,a&c)                          ^0fF4^07 : surround sound
 ^0fo^07 : scopes                                     ^0fF5^07 , ^0fF6^07 : change panning (^0f,^07;^0f.^07)
 ^0fg^07 : graphic analyser (shift-^0fg^07 for big gsa)     ^0fF7^07 , ^0fF8^07 : change balance (^0f/^07,^0f*^07)
 ^0fn^07 : note dots                                  ^0fF9^07 , ^0fF10^07: change speed
 ^0fw^07 : wuerfel mode                               ^0fF11^07, ^0fF12^07: change pitch
-^0fm^07 : song message                                     ^0f\\^07 : lock pitch+speed
-^0fh^07 : help                                        alt-^0fF2^07 : save settings (session
-^0ff^07 : file-selector                               alt-^0fF3^07 : reset settings    only)
-                                                      alt-^0fF4^07 : "factory defaults"
-                                              ^0fbackspace^07: toggle interpolation
+^0f|^07 : song message                                     ^0f\\^07 : lock pitch+speed
+^0fh^07 : help                                 ctrl-shift-^0fF2^07 : save settings (session
+^0ff^07 : file selector                        ctrl-shift-^0fF3^07 : reset settings    only)
+                                         ctrl-shift-^0fF4^07 : "factory defaults"
+                                             ^0fbackspace^07 : toggle interpolation
   ^0f-^07 ^0fModule^07 ^0fKeys^07 ^0f-^07
      ^0f>^07   : next pattern
      ^0f<^07   : previous pattern                        ^0f-^07 ^0fChannel^07 ^0fKeys^07 ^0f-^07
 ctrl-^0f^07   : go 8 rows up                         ^0f^07, ^0f^07 : select previous channel
-ctrl-^0f^07   : go 8 rows down                       ^0f\d^07, ^0f^07 : select next channel
+ctrl-^0f^07   : go 8 rows down                       ^0f^07, ^0f^07 : select next channel
 ctrl-^0fhome^07: restart module                       ^0f1^07..^0f0^07 : goto and toggle channel
-                                           ctrl-^0f1^07..^0f0^07 : goto and solo channel
+
   ^0f-^07 ^0fPlayer^07 ^0fKeys^07 ^0f-^07                                  ^0fq^07 : toggle selected channel
-    ^0freturn^07 : play next module                      ^0fs^07 : solo selected channl
+    ^0freturn^07 : play next module                      ^0fs^07 : solo selected channel
   (ctrl-)^0fp^07 : pause module (immediate)       ctrl-^0fq^07/^0fs^07 : turn on all channels
-  (ctrl-)^0fd^07 : dos-shell (no reminder)               ^0fc^07 : toggle channel mode
+         ^0fd^07 : open a shell                          ^0fc^07 : toggle channel mode
    ^0fesc^07 ^0fesc^07 : e-s-c-a-p-e                               (none/short/long/side)
-    ^0fins^07, ^0ff^07 : file-selector
-         ^0fz^07 : tog. scr. hgt. (25/50)
-    ctrl-^0fz^07 : tog. scr. hgt. (25/30)
-     alt-^0fz^07 : tog. scr. wid. (80/132)
-     alt-^0fx^07 : norm. scr. mode (80*25)
-         ^0fx^07 : xtended scr. mode (132*60)
+    ^0fins^07, ^0ff^07 : file selector
+         ^0fz^07 : tog. font (8x8/8x16)
+    ctrl-^0fz^07 : tog. scr. minor
+     alt-^0fz^07 : tog. scr. major
+     alt-^0fx^07 : norm. scr. mode (80x25)
+         ^0fx^07 : xtended scr. mode (160x128)
 
 ^0bInstrument^07 ^0bMode:^07  ^0b<i>^07
 =====================
 
-     ^0fi^07 - toggle instrument mode  (none / short / full / \[side\])
+     ^0fi^07 - toggle instrument mode  (none / short / long / \[side\])
   ^0fpgup^07 - scroll up                         ctrl-^0fpgup^07 - scroll up fast
   ^0fpgdn^07 - scroll down                       ctrl-^0fpgdn^07 - scroll down fast
   ^0fhome^07 - go to the top                         alt-^0fi^07 - clear instrument flags
@@ -857,7 +857,7 @@ ctrl-^0fpgup^07/^0fdn^07 - change analyser gain
 ^0bScopes:^07  ^0b<o>^07
 ============
 
-           ^0fo^07 - toggle mode (all / single scope)
+           ^0fo^07 - toggle mode (logical / physical / stereo / single channel)
   ^0ftab^07, alt-^0fo^07 - toggle triggered scopes
      ^0fpgup^07/^0fdn^07 - stretch / squeeze scope output
 

--- a/doc/opencp.dox.in
+++ b/doc/opencp.dox.in
@@ -838,7 +838,7 @@ in manual mode:
 =================================
 
          ^0ftab^07 - toggle analyser's colors
-           ^0fa^07 - toggle channel mode (mixed output / single channel)
+       alt-^0fa^07 - toggle channel mode (stereo / mono / single channel)
         ^0fhome^07 - set maximum frequency range to appoximately 2500Hz
      ^0fpgup^07/^0fdn^07 - change visible frequency range
 ctrl-^0fpgup^07/^0fdn^07 - change analyser gain

--- a/doc/opencp.dox.in
+++ b/doc/opencp.dox.in
@@ -768,7 +768,7 @@ You can use all these keys throughout the player except in special modes.
 ^0fm^07 : song message                                     ^0f\\^07 : lock pitch+speed
 ^0fh^07 : help                                        alt-^0fF2^07 : save settings (session
 ^0ff^07 : file-selector                               alt-^0fF3^07 : reset settings    only)
-^0fe^07 : echo menu / editor                          alt-^0fF4^07 : "factory defaults"
+                                                      alt-^0fF4^07 : "factory defaults"
                                               ^0fbackspace^07: toggle interpolation
   ^0f-^07 ^0fModule^07 ^0fKeys^07 ^0f-^07                              ctrl-^0f<-^07 : change filter
      ^0f>^07   : next pattern
@@ -783,7 +783,6 @@ ctrl-^0fhome^07: restart module                       ^0f1^07..^0f0^07 : goto an
   (ctrl-)^0fd^07 : dos-shell (no reminder)               ^0fc^07 : toggle channel mode
    ^0fesc^07 ^0fesc^07 : e-s-c-a-p-e                               (none/short/long/side)
     ^0fins^07, ^0ff^07 : file-selector
-         ^0fe^07 : echo menu / editor
          ^0fz^07 : tog. scr. hgt. (25/50)
     ctrl-^0fz^07 : tog. scr. hgt. (25/30)
      alt-^0fz^07 : tog. scr. wid. (80/132)

--- a/doc/opencp.dox.in
+++ b/doc/opencp.dox.in
@@ -770,7 +770,7 @@ You can use all these keys throughout the player except in special modes.
 ^0ff^07 : file-selector                               alt-^0fF3^07 : reset settings    only)
                                                       alt-^0fF4^07 : "factory defaults"
                                               ^0fbackspace^07: toggle interpolation
-  ^0f-^07 ^0fModule^07 ^0fKeys^07 ^0f-^07                              ctrl-^0f<-^07 : change filter
+  ^0f-^07 ^0fModule^07 ^0fKeys^07 ^0f-^07
      ^0f>^07   : next pattern
      ^0f<^07   : previous pattern                        ^0f-^07 ^0fChannel^07 ^0fKeys^07 ^0f-^07
 ctrl-^0f^07   : go 8 rows up                         ^0f^07, ^0f^07 : select previous channel

--- a/doc/opencp.dox.in
+++ b/doc/opencp.dox.in
@@ -802,7 +802,6 @@ ctrl-^0fhome^07: restart module                       ^0f1^07..^0f0^07 : goto an
 ==================
 
           ^0fspace^07 - toggle track mode (follow / manual)
-   ctrl-^0fpgup^07/^0fdn^07 - scroll instruments (for multiview)
            ^0fhome^07 - optimum channel number for current module
 
 in follow mode:

--- a/doc/opencp.dox.in
+++ b/doc/opencp.dox.in
@@ -841,7 +841,7 @@ in manual mode:
            ^0fa^07 - toggle channel mode (mixed output / single channel)
         ^0fhome^07 - set maximum frequency range to appoximately 2500Hz
      ^0fpgup^07/^0fdn^07 - change visible frequency range
-ctrl-^0fpgup^07/^0fdn^07 - scroll instruments (for multiview)
+ctrl-^0fpgup^07/^0fdn^07 - change analyser gain
 
 ^0bGraphic^07 ^0bSpectrum^07 ^0bAnalyser:^07  ^0b<g>^07
 ===============================

--- a/doc/texi/player.texi
+++ b/doc/texi/player.texi
@@ -540,7 +540,7 @@ more than 4 channels.
 @section Key Reference
 @multitable @columnfractions .3 .7
 @item
-@key{ESC}
+@key{ESC} @key{ESC}
 @tab
 quit the player
 @item
@@ -552,15 +552,15 @@ help
 @tab
 volume up/down
 @item
-@key{CTRL}+@{@key{F2}, @key{F3}@}
+@key{SHIFT}+@{@key{F2}, @key{F3}@}
 @tab
 change amplification
 @item
-@key{ALT}+@key{F2}
+@key{CTRL}+@key{SHIFT}+@key{F2}
 @tab
 @emph{save} current configuration
 @item
-@key{ALT}+@key{F3}
+@key{CTRL}+@key{SHIFT}+@key{F3}
 @tab
 load previously saved configuration
 @item
@@ -568,7 +568,7 @@ load previously saved configuration
 @tab
 surround on/off
 @item
-@key{ALT}+@key{F4}
+@key{CTRL}+@key{SHIFT}+@key{F4}
 @tab
 load default configuration
 @item
@@ -576,7 +576,7 @@ load default configuration
 @tab
 change panning
 @item
-@key{CTRL}+@{@key{F5}, @key{F6}@}
+@key{SHIFT}+@{@key{F5}, @key{F6}@}
 @tab
 adjust reverb
 @item
@@ -584,7 +584,7 @@ adjust reverb
 @tab
 change balance
 @item
-@key{CTRL}+@{@key{F7}, @key{F8}@}
+@key{SHIFT}+@{@key{F7}, @key{F8}@}
 @tab
 adjust chorus
 @item
@@ -592,7 +592,7 @@ adjust chorus
 @tab
 change speed
 @item
-@key{ALT}+@key{F9}
+@key{|}
 @tab
 song message
 @item
@@ -600,29 +600,13 @@ song message
 @tab
 change pitch
 @item
-@key{F11}
-@tab
-toggle between 6581 and 8580 (sidplayer only)
-@item
-@key{F12}
-@tab
-toggle between PAL and NTSC (sidplayer only)
-@item
 @key{CTRL}+@key{F12}
 @tab
 (un)lock speed and pitch
 @item
 @key{1}..@key{0}
 @tab
-solo channel 1..10
-@item
-@key{ALT}+@key{1}..@key{0}
-@tab
-solo channel 11..20
-@item
-@key{CTRL}+@key{1}..@key{0}
-@tab
-solo channel 21..30
+select and toggle channel 1..10
 @item
 @key{a}
 @tab
@@ -642,11 +626,11 @@ channel mode
 @item
 @key{d}
 @tab
-goto DOS
+open a shell
 @item
 @key{f}
 @tab
-goto fileselector
+open fileselector
 @item
 @key{g}
 @tab
@@ -658,7 +642,7 @@ graphic spectrum analyzer in 1024x768
 @item
 @key{ALT}+@key{g}
 @tab
-toggle fast/fine algorithm
+toggle fast/fine algorithm in graphic spectrum analyzer
 @item
 @key{h}
 @tab
@@ -692,10 +676,6 @@ pattern looping on/off
 @tab
 volume control
 @item
-@key{CTRL}+@key{m}
-@tab
-same as @key{Enter}
-@item
 @key{n}
 @tab
 note dots
@@ -711,10 +691,6 @@ behaves like @key{Tab} in this mode
 @key{p}
 @tab
 pause
-@item
-@key{ALT}+@key{p}
-@tab
-pause screen
 @item
 @key{q}
 @tab
@@ -806,7 +782,7 @@ scroll in current window
 @item
 @key{CTRL}+@{@key{Pgup}, @key{Pgdown}@}
 @tab
-scroll in instruments window (eXtended mode)
+scroll a page in instruments window
 @item
 @key{Home}, @key{End}
 @tab


### PR DESCRIPTION
The Quickhelp was very useful to me since I had forgotten a lot of key combinations and the Alt + K dialogue is very verbose. It was however quite out of date, so the main focus with this PR is to remove invalid keys and update existing entries, not to document all new features.
