### PR TITLE
devpcoreaudio.c: fix build failure

### DIFF
--- a/devp/devpcoreaudio.c
+++ b/devp/devpcoreaudio.c
@@ -477,7 +477,7 @@ static int devpCoreAudioPlay (uint32_t *rate, enum plrRequestFormat *format, str
 	return 1;
 }
 
-static void devpCoreAudioGetStats (uint64_t *processed);
+static void devpCoreAudioGetStats (uint64_t *processed)
 {
 	plrDriverAPI->ringbufferAPI->get_stats (devpCoreAudioRingBuffer, processed);
 }


### PR DESCRIPTION
Fixes:

    devpcoreaudio.c:481:1: error: expected identifier or '('
    {
    ^
