### PR TITLE
Adjust sample speed in Amiga MOD files

### DIFF
--- a/playxm/xmlmod.c
+++ b/playxm/xmlmod.c
@@ -310,7 +310,7 @@ static int loadmod (struct cpifaceSessionAPI_t *cpifaceSession, struct xmodule *
 		sip->length=length;
 		sip->loopstart=loopstart;
 		sip->loopend=loopstart+looplength;
-		sip->samprate=8363;
+		sip->samprate=(opt & 4) ? 8363 : 8287; // FastTracker II uses 8363Hz as the base-sample frequency, while PAL Amiga uses 8287.13Hz
 		sip->type=looplength?mcpSampLoop:0;
 	}
 


### PR DESCRIPTION
[playxm] MOD (Amiga ProTracker 1.1b), MODd (Dual Module Player) and MODt (old Amiga ProTracker) now use 8287Hz as the base-freqeuncy for samples matching Amiga PAL machines, while MODf (Fast Tracker II) still use 8363Hz.

If a song now plays the samples slightly too fast, they should be marked with MODf (press <ALT>+<E> in the filebrowser, move the cursor over to "type:" and press <ENTER>)


This should fix speed issue mentioned in #124