### PR TITLE
[playqoa] Wrap default case statement

### DIFF
--- a/playqoa/qoaplay.c
+++ b/playqoa/qoaplay.c
@@ -223,6 +223,7 @@ static void qoaIdler(struct cpifaceSessionAPI_t *cpifaceSession)
 				}
 				break;
 			default:
+			{
 				int16_t *src = qoa_audio_frame_buffer;
 				int16_t *dst = qoa_audio_ring_buffer + (pos1 << 1); /* we only need << 1, since qoa_audio_ring_buffer is int16_t already */ 
 				int extra = qoa.channels - 2;
@@ -242,6 +243,7 @@ static void qoaIdler(struct cpifaceSessionAPI_t *cpifaceSession)
 					dst += extra;
 				}
 				break;
+			}
 		}
 		cpifaceSession->ringbufferAPI->head_add_samples (qoa_audio_ring_position, samplefill);
 		qoa_samplepos += samplefill;


### PR DESCRIPTION
```
int16_t *src = qoa_audio_frame_buffer;
```
is treated as a declaration, so it is better to wrap the case statement by `{}`, it could be failed to build some environment with below error.

```
  qoaplay.c:226:5: error: expected expression
    226 |                                 int16_t *src = qoa_audio_frame_buffer;
        |                                 ^
  qoaplay.c:231:18: error: use of undeclared identifier 'src'
    231 |                                         *(dst++) = *src;
        |                                                     ^
  qoaplay.c:232:19: error: use of undeclared identifier 'src'
    232 |                                         *(dst++) = *(src++);
        |                                                      ^
  qoaplay.c:239:18: error: use of undeclared identifier 'src'
    239 |                                         *(dst++) = *src;
        |                                                     ^
  qoaplay.c:240:19: error: use of undeclared identifier 'src'
    240 |                                         *(dst++) = *(src++);
        |                                                      ^
  5 errors generated.
  make[1]: *** [qoaplay.o] Error 1
```