### PR TITLE
fix: handle declaration after label

### DIFF
--- a/filesel/pfilesel.c
+++ b/filesel/pfilesel.c
@@ -2405,7 +2405,7 @@ static void fsEditRegisterExt(void)
 	}
 
 superbreak:
-Repaint:
+Repaint: ;
 	int mlWidth = 80;
 	int mlHeight = plScrHeight - 3;
 	int mlTop = 2;


### PR DESCRIPTION
Fix a clang toolchain issue in filesel/pfilesel.c by adding an empty statement
after the Repaint: label before declarations.

Reference: https://github.com/Homebrew/homebrew-core/pull/270042
