### PR TITLE
README: Add info about Docker and revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ To get curses up and running with colors, you need to run ocp like this
 
 `TERM=xterm-color ocp-curses`
 
+# Docker images
+
+Files for building Docker images for Open Cubic Player are available in [this repository](https://github.com/hhromic/opencubicplayer-docker).
+
+Ready to use images can be pulled directly from the GitHub Container Registry of the repository.
+
+Refer to the [README file](https://github.com/hhromic/opencubicplayer-docker?tab=readme-ov-file#readme) for usage information and more details.
+
 # Sample sources of where to find music
 
 https://modarchive.org/

--- a/README.md
+++ b/README.md
@@ -73,12 +73,19 @@ Supported files using [AdPlug](http://adplug.github.io/), for formats designed f
 
 Extension | Notes
 :-------- | :----
-`*.HSC`   |
-`*.SNG`   |
-`*.D00`   |
-`*.ADL`   |
-`*.VGM`   |
+`*.A2M`, `*.A2T` | [AdLib Tracker 2 by subz3ro](https://www.adlibtracker.net/)
+`*.ADL`   | Coktel Vision Adlib Music
+`*.AMD`   | Amusic tracker by Elyssis
+`*.BAM`   | [Bob's Adlib Music](https://rpg.hamsterrepublic.com/ohrrpgce/BAM_Format)
+`*.CMF`   | [Creative Music File Format by Creative Technology](https://www.vgmpf.com/Wiki/index.php?title=CMF)
+`*.D00`   | EdLib
+`*.HSC`   | HSC Adlib Composer by Hannes Seifert, [HSC-Tracker by Electronic Rats](https://demozoo.org/productions/293837/)
+`*.IMF`, `*.WLF`, `*.ADLIB` | Apogee IMF, game music
 `*.RAD`   | [Reality AdLib Tracker](https://www.3eality.com/productions/reality-adlib-tracker)
+`*.SNG`   | SNGPlay by BUGSY of OBSESSION
+`*.SNG`   | Adlib Tracker 1.0 by Dj-Tj
+`*.VGM`   |
+`*.XMS`   | XMS-Tracker by MaDoKaN/E.S.G
 
 Supported files for [HivelyTracker](http://www.hivelytracker.co.uk/) tracked music, using code from the original tracker repository:
 

--- a/README.md
+++ b/README.md
@@ -77,17 +77,50 @@ Extension | Notes
 :-------- | :----
 `*.A2M`, `*.A2T` | [AdLib Tracker 2 by subz3ro](https://www.adlibtracker.net/)
 `*.ADL`   | Coktel Vision Adlib Music
+`*.ADL`   | Westwood ADL
 `*.AMD`   | Amusic tracker by Elyssis
 `*.BAM`   | [Bob's Adlib Music](https://rpg.hamsterrepublic.com/ohrrpgce/BAM_Format)
+`*.CFF`   | BoomTracker 4.0 by CUD
 `*.CMF`   | [Creative Music File Format by Creative Technology](https://www.vgmpf.com/Wiki/index.php?title=CMF)
+`*.CMF`   | [SoundFX Macs Opera tracker by Linel](https://www.vgmpf.com/Wiki/index.php?title=CMF_\(MACS_Opera\))
 `*.D00`   | EdLib
+`*.DFM`   | Digital-FM by R.Verhaag
+`*.DMO`   | Twin TrackPlayer by TwinTeam
+`*.DRO`   | DOSBox Raw OPL
+`*.DTM`   | DeFy Adlib Tracker by DeFy
+`*.GOT`   | [God Of Thunder Music by Roy Davis of Adept Software](https://moddingwiki.shikadi.net/wiki/God_of_Thunder)
 `*.HSC`   | HSC Adlib Composer by Hannes Seifert, [HSC-Tracker by Electronic Rats](https://demozoo.org/productions/293837/)
+`*.HSQ`, `*.SQX`, `*.SDB`, `*.AGD`, `*.HA2` | Herbulot AdLib System (HERAD) by Remi Herbulot
+`*.HSP`   | HSC Packed by Number Six / Aegis Corp.
 `*.IMF`, `*.WLF`, `*.ADLIB` | Apogee IMF, game music
+`*.JBM`   | JBM (Johannes Bjerregaard's) Adlib Music Format
+`*.KSM`   | [Ken Silverman](https://advsys.net/ken/)'s Music Format
+`*.LDS`   | LOUDNESS Sound System <!-- https://ocremix.org/artist/230/andras-molnar https://tyrian.fandom.com/wiki/Andreas_Molnar http://www.loudness.de/ -->
+`*.M`     | Ultima 6 Music
+`*.MAD`   | Mlat Adlib Tracker
+`*.MDI`   | AdLib MIDIPlay File Format by Ad Lib Inc.
+`*.MID`, `*.SCI`, `*.LAA` | Sierra's AdLib Audio File Format, MIDI Audio File Format, LucasArts AdLib Audio File Format by LucasArts
+`*.MKJ`   | MKJamz by M \ K Productions
+`*.MSC`   | Adlib MSC Player <!-- Likely refers to software that was buneled with Adlib MSC 16 cards, JukeBox Playback Program https://www.opl3.com/wp-content/uploads/2019/08/amsc-JukeBox-Playback-Program.pdf -->
+`*.MTK`   | MPU-401 Trakker by SuBZeR0
+`*.MTR`   | Arkham Master Tracker 2.4
+`*.MUS`, `*.MDY`, `*.IMS` | AdLib MIDI Music Format by Ad Lib Inc., IMPlay Song Format
+`*.PIS`   | Beni Tracker PIS Player
+`*.PLX`   | PALLADIX Sound System
+`*.RAC`, `*.RAW` | Raw AdLib Capture
 `*.RAD`   | [Reality AdLib Tracker](https://www.3eality.com/productions/reality-adlib-tracker)
-`*.SNG`   | SNGPlay by BUGSY of OBSESSION
+`*.RIX`, `*.MKF` | Softstar RIX OPL Music
+`*.ROL`   | [Adlib Visual Composer by AdLib Inc.](https://www.vgmpf.com/Wiki/index.php/AdLib_Visual_Composer_\(DOS\))
+`*.S3M`, `*.AS3M` | [Scream Tracker 3](https://en.wikipedia.org/wiki/Scream_Tracker)
+`*.SA2`, `*.SAT` | [Surprise! Adlib Tracker 2](https://www.pouet.net/prod.php?which=70029) by Surprise! Productions
 `*.SNG`   | Adlib Tracker 1.0 by Dj-Tj
-`*.VGM`   |
+`*.SNG`   | [Faust Music Creator](https://www.pouet.net/prod.php?which=55235) by FAUST
+`*.SNG`   | SNGPlay by BUGSY of OBSESSION
+`*.SOP`   | Note Sequencer by Lee Ho Bum (sopepos)
+`*.VGM`, `*.VGZ` | [Video Game Music](https://www.vgmpf.com/Wiki/index.php?title=VGM)
+`*.XAD`   | Various eXotic ADlib Formats by Riven the Mage
 `*.XMS`   | XMS-Tracker by MaDoKaN/E.S.G
+`*.XSM`   | eXtra Simple Music by Davey W Taylor
 
 Supported files for [HivelyTracker](http://www.hivelytracker.co.uk/) tracked music, using code from the original tracker repository:
 

--- a/README.md
+++ b/README.md
@@ -183,15 +183,17 @@ Keys | Description
 
 See: <https://repology.org/project/ocp-open-cubic-player/versions>
 
-## Unifont.ttf?
+## GNU Unifont
 
-When you compile/install and have enabled X11/SDL support, the unifont TTF files are needed. This is a 8x16 font that has a main goal of being UTF-8/Unicode complete.
-
+[GNU Unifont files](https://unifoundry.com/unifont/) are required when X11/SDL support is enabled.
+This is an 8x16 font that has the main goal of being UTF-8/Unicode complete.
 For special scripts it will look incorrect, but the character-set should be complete.
 
-In most systems this font will be installed in `/usr/share/fonts/truetype/unifont/` or `/usr/share/fonts/opentype/unifont/`. If this path is different for your system, you can provide the correct path with `./configure --with-unifontdir-ttf=/your/path` and/or `./configure --with-unifontdir-otf=/your/path`.
+In most systems, Unifont files will be installed in `/usr/share/fonts/truetype/unifont/` or `/usr/share/fonts/opentype/unifont/`.
+If this path is different for your system, you can configure the correct path using `--with-unifontdir-ttf=/your/path` and/or `--with-unifontdir-otf=/your/path` when invoking `./configure`.
 
-If the font-files on your system is not named exactly `unifont.ttf`, `unifont_csur.ttf` and `unifont_upper.ttf`, you can configure alternative filenames using `./configure --with-unifont-ttf=/your/path/UniFont.ttf --with-unifont-csur-ttf=/your/path/UniFont-CSUR.ttf --with-unifont-upper-ttf=/your/path/UniFont-Upper.ttf`. Same for opentype version of the files by using `--with-unifont-otf`, `--with-unifont-csur-otf` and `--with-unifont-upper-otf`.
+If the Unifont files on your system are not named exactly `unifont.ttf`, `unifont_csur.ttf` and `unifont_upper.ttf`, the filenames can be configured using `--with-unifont-ttf=/your/path/UniFont.ttf`, `--with-unifont-csur-ttf=/your/path/UniFont-CSUR.ttf` and/or `--with-unifont-upper-ttf=/your/path/UniFont-Upper.ttf`.
+For the OpenType version of the files, use `--with-unifont-otf`, `--with-unifont-csur-otf` and/or `--with-unifont-upper-otf`.
 
 If the filenames on your system contains version numbers, we ask you to fill a bug-report to your system provider and ask them to add symlinks without version numbers in them.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Supported Audio-CD files:
 
 Extension | Notes
 :-------- | :----
-`*.CDA`   | Linux support only, using digital read out API.
+`*.CDA`   | Linux support only, using `ioctl()` for [digital audio extraction](https://docs.kernel.org/userspace-api/ioctl/cdrom.html).
 `*.CUE`   | [Cue sheet metadata](https://en.wikipedia.org/wiki/Cue_sheet_(computing))
 `*.TOC`   | [CD recorder disc-at-once (cdrdao)](https://en.wikipedia.org/wiki/Cdrdao)
 

--- a/README.md
+++ b/README.md
@@ -1,216 +1,212 @@
-# What is it?
+# Open Cubic Player
 
-UNIX port of Open Cubic Player, which is a text-based player with some few graphical views. Visual output can be done through nCurses, Linux console (VCSA + FrameBuffer), X11 or SDL/SDL2. It can be compiled on various different unix based operating systems.
+Unix port of [Open Cubic Player](https://www.cubic.org/player/), which is a text-based player with some few graphical views. Visual output can be done through nCurses, Linux console (VCSA + FrameBuffer), X11 or SDL/SDL2. It can be compiled on various different Unix-based operating systems.
 
 ![Screenshot](doc/screenshot-01.png)
 
-# What can it play?
-
-Amiga style [modules](https://en.wikipedia.org/wiki/Module_file) files with more (Amiga compressed files will be decompressed using [ancient](https://github.com/temisu/ancient)): <!-- http://fileformats.archiveteam.org/wiki/Amiga_Module -->
-- \*.AMS, [Velvet Studio](http://www.pouet.net/prod.php?which=64890) and [Extreme's Tracker](https://www.pouet.net/prod.php?which=88711)
-- \*.DMF, [X-Tracker](http://www.pouet.net/prod.php?which=55233)
-- \*.IT, [Impulse Tracker](https://en.wikipedia.org/wiki/Impulse_Tracker) or use the modern [Schism Tracker](http://schismtracker.org/)
-- \*.MDL, [DigiTrakker](http://www.pouet.net/prod.php?which=13371), now developed as [MilkyTracker](https://en.wikipedia.org/wiki/MilkyTracker)
-- \*.MOD, [ProTracker](https://en.wikipedia.org/wiki/ProTracker) or use the modern [ProTracker Clone](https://github.com/8bitbubsy/pt2-clone)
-- \*.MTM, [MultiTracker Module Editor](http://www.pouet.net/prod.php?which=13362)<!-- - \*.MXM, mxmplayer - mini GUS player, intermediate file format to support .XM and similiar files -->
-- \*.NST, [NoiseTracker](https://en.wikipedia.org/wiki/NoiseTracker)
-- \*.OKT, [Oktalyzer](http://www.robotplanet.dk/amiga/oktalyzer/)<!-- https://www.wikidata.org/wiki/Q21041560 -->
-- \*.PTM, [PolyTracker](http://justsolve.archiveteam.org/wiki/Poly_Tracker_module)
-- \*.STM, [Scream Tracker 2](https://en.wikipedia.org/wiki/Scream_Tracker)
-- \*.S3M, [Scream Tracker 3](https://en.wikipedia.org/wiki/Scream_Tracker)
-- \*.ULT, [Ultra Tracker](http://www.pouet.net/prod.php?which=63386)
-- \*.WOW, Grave Composer <!-- http://fileformats.archiveteam.org/wiki/Grave_Composer_module -->
-- \*.XM, [FastTracker 2](https://en.wikipedia.org/wiki/FastTracker_2) or use the modern [FastTracker 2 Clone](https://github.com/8bitbubsy/ft2-clone)
-- \*.669, [Composer 669](http://www.pouet.net/prod.php?which=63357) <!-- https://www.wikidata.org/wiki/Q9135198 -->
-
-Code from [STYMulator](http://atariarea.krap.pl/stymulator/) to play music from [Atari ST](https://en.wikipedia.org/wiki/Atari_ST#Technical_specifications) \([Yamaha YM2149](https://en.wikipedia.org/wiki/General_Instrument_AY-3-8910)\):
-- \*.YM
-
-Fork of [libsidplayfp](https://sourceforge.net/p/sidplay-residfp/wiki/Home/) to play music from [C64](https://en.wikipedia.org/wiki/Commodore_64) \([SID 6581/8580](https://en.wikipedia.org/wiki/MOS_Technology_6581)\):
-- \*.SID
-- \*.RSID
-
-Code from [aylet](http://www.svgalib.org/rus/aylet.html) to play music from [ZX Spectrum](https://en.wikipedia.org/wiki/ZX_Spectrum)/[Amstrad CPC](https://en.wikipedia.org/wiki/Amstrad_CPC) \([Yamaha YM2149](https://en.wikipedia.org/wiki/General_Instrument_AY-3-8910)\):
-- \*.AY
-
-Audio Files (both compressed and PCM styled):
-- \*.WAV
-- \*.OGG
-- \*.FLAC
-- \*.MP2
-- \*.MP3
-- \*.QOA [Quite OK Audio](https://qoaformat.org/)
-
-Audio CDs: Linux support only, using digital read out API
-- \*.CDA
-
-Fork of [TiMidity++](http://timidity.sourceforge.net/) is used to play [MIDI](https://en.wikipedia.org/wiki/MIDI#General_MIDI):
-- \*.MID
-
-[AdPlug](http://adplug.github.io/) can read a wide range of music formats designed for the [OPL2](https://en.wikipedia.org/wiki/Yamaha_YM3812)/[OPL3](https://en.wikipedia.org/wiki/Yamaha_YMF262) Adlib sound chip. Examples:
-- \*.HSC
-- \*.SNG
-- \*.D00
-- \*.ADL
-- \*.VGM
-- \*.RAD [Reality Adlib Tracker](https://www.3eality.com/productions/reality-adlib-tracker)
-
-[HivelyTracker](http://www.hivelytracker.co.uk/) tracked music, using code from the original tracker repository:
-- \*.HVL [Hively Tracker](https://github.com/pete-gordon/hivelytracker)
-- \*.AHX [AHX](http://amigascne.org/abyss/ahx/) or use the not yet existant modern [AHX Clone](https://github.com/8bitbubsy/ahx-clone)
-
-[Game Music Emulator](https://bitbucket.org/mpyne/game-music-emu/wiki/Home) Support for various retro game consoles:
-- \*.GBS, [GameBoy Sound System](https://en.wikipedia.org/wiki/Game_Boy_Sound_System)
-- \*.GYM, [Genesis YM2612](https://vgmrips.net/wiki/GYM_File_Format)
-- \*.HES, [Hudson Entertainment Sound](http://www.purose.net/befis/download/nezplug/hesspec.txt)
-- \*.KSS, [Konami Sound System?](http://www.vgmpf.com/Wiki/index.php?title=KSS)
-- \*.NSF \*.NSFe, [Nintendo Sound Format](https://www.nesdev.org/wiki/NSF)
-- \*.SAP, [Slight Atari Player](https://asap.sourceforge.net/sap-format.html)
-- \*.SPC, [Super Nintendo / Super Famicom SPC-700 co-processor](http://vspcplay.raphnet.net/spc_file_format.txt)
-- \*.VGM \*.VGZ, [Video Game Music](https://vgmrips.net/wiki/VGM_File_Format)
-
-# Integrated support for modland.com
-
-Built into the file-browser is support for directly browsing https://modland.com utilizing curl. You need to initially fetch the database containing all the file names, this is available via modland.com/setup.dev inside built-in file browser.
-
-# Manual Page
-
-https://manpages.debian.org/testing/opencubicplayer/ocp.1.en.html
-
-# Usage
-
-<kbd>esc</kbd><kbd>esc</kbd>: exit the program
-
-<kbd>alt</kbd> + <kbd>k</kbd>: List the available keyshort-cuts in the current view
-
-## While playing
-
-Note: if letters are capital, press them with <kbd>shift</kbd>
-
-<kbd>Enter</kbd>: next file from the playlist, if playlist is empty it opens the file-browser
-
-<kbd>f</kbd>: File-browser
-
-<kbd><</kbd>: Rewind
-
-<kbd>></kbd>: Fast Forward
-
-<kbd>a</kbd>: Text FFT analyzer, <kbd>A</kbd>: toggle FFT analyzer, <kbd>tab</kbd>, toggle colors
-
-<kbd>b</kbd>: Phase viewer
-
-<kbd>c</kbd>: Text Channel viewer
-
-<kbd>d</kbd>: Start a shell (only works if using the console/curses version)
-
-<kbd>s</kbd>: un/Silence channel
-
-<kbd>q</kbd>: un/Quiet other channels (solo/unsolo)
-
-<kbd>t</kbd>: Text Track viewer
-
-<kbd>g</kbd>: Lo-Res FFT analyzer + history
-<kbd>G</kbd>: High-Res FFT analyzer + history
-
-<kbd>o</kbd>: Oscilloscope
-
-<kbd>v</kbd>: Peak power level
-
-<kbd>w</kbd>: Wurfel mode (requires animation files to be present)
-
-<kbd>m</kbd>: Volume control
-
-<kbd>n</kbd>: Note dots
-
-<kbd>x</kbd> / <kbd>alt</kbd> + <kbd>x</kbd>: Extended mode / normal mode toggle
-
-<kbd>'</kbd>: Link view
-
-<kbd>,</kbd> / <kbd>.</kbd>: Fine panning
-
-<kbd>+</kbd> / <kbd>-</kbd>: Fine volume
-
-<kbd>*</kbd> / <kbd>/</kbd>: Fine balance
-
-<kbd>Backspace</kbd>: Toggle filter
-
-<kbd>f1</kbd> / <kbd>?</kbd> / <kbd>h</kbd>: Online Help
-
-<kbd>f2</kbd>: Lower Volume
-
-<kbd>f3</kbd>: Increase Volume
-
-<kbd>f4</kbd>: Toggle Surround
-
-<kbd>f5</kbd>: Panning left
-
-<kbd>f6</kbd>: Panning right
-
-<kbd>f7</kbd>: Balance left
-
-<kbd>f8</kbd>: Balance right
-
-<kbd>f9</kbd>: Decrease playback speed
-
-<kbd>f10</kbd>: Increase playback speed
-
-<kbd>\\</kbd>: Toggle pitch/speed lock (if fileformat makes this possible)
-
-<kbd>f11</kbd>: Decrease playback pitch
-
-<kbd>f12</kbd>: Increase playback pitch
-
-## File browser
-
-<kbd>alt</kbd> + <kbd>e</kbd>: Edit meta-information
-
-<kbd>alt</kbd> + <kbd>i</kbd>: Toggle file-list columns (long filename, title, etc.)
-
-<kbd>alt</kbd> + <kbd>c</kbd>: Opens a system options list
-
-<kbd>Insert</kbd>: Add to playlist
-
-<kbd>Delete</kbd>: Remove from playlist
-
-<kbd>Tab</kbd>: Move cursor between filelist and playlist
-
-# Original
-
-https://www.cubic.org/player/
-
-# Installing binaries on Linux
-
-https://repology.org/project/ocp-open-cubic-player/versions
-
-# Unifont.ttf?
+## Supported Formats
+
+Amiga-style [module files](https://en.wikipedia.org/wiki/Module_file) and other module files (Amiga compressed files are decompressed using [ancient](https://github.com/temisu/ancient)): <!-- http://fileformats.archiveteam.org/wiki/Amiga_Module -->
+
+Extension | Notes
+:-------- | :----
+`*.AMS`   | [Velvet Studio](http://www.pouet.net/prod.php?which=64890) and [Extreme's Tracker](https://www.pouet.net/prod.php?which=88711)
+`*.DMF`   | [X-Tracker](http://www.pouet.net/prod.php?which=55233)
+`*.IT`    | [Impulse Tracker](https://en.wikipedia.org/wiki/Impulse_Tracker) or the modern [Schism Tracker](http://schismtracker.org/)
+`*.MDL`   | [DigiTrakker](http://www.pouet.net/prod.php?which=13371) or the modern [MilkyTracker](https://en.wikipedia.org/wiki/MilkyTracker)
+`*.MOD`   | [ProTracker](https://en.wikipedia.org/wiki/ProTracker) or the modern [ProTracker Clone](https://github.com/8bitbubsy/pt2-clone)
+`*.MTM`   | [MultiTracker Module Editor](http://www.pouet.net/prod.php?which=13362) <!-- - \*.MXM, mxmplayer - mini GUS player, intermediate file format to support .XM and similiar files -->
+`*.NST`   | [NoiseTracker](https://en.wikipedia.org/wiki/NoiseTracker)
+`*.OKT`   | [Oktalyzer](http://www.robotplanet.dk/amiga/oktalyzer/) <!-- https://www.wikidata.org/wiki/Q21041560 -->
+`*.PTM`   | [PolyTracker](http://justsolve.archiveteam.org/wiki/Poly_Tracker_module)
+`*.STM`   | [Scream Tracker 2](https://en.wikipedia.org/wiki/Scream_Tracker)
+`*.S3M`   | [Scream Tracker 3](https://en.wikipedia.org/wiki/Scream_Tracker)
+`*.ULT`   | [Ultra Tracker](http://www.pouet.net/prod.php?which=63386)
+`*.WOW`   | Grave Composer <!-- http://fileformats.archiveteam.org/wiki/Grave_Composer_module -->
+`*.XM`    | [FastTracker 2](https://en.wikipedia.org/wiki/FastTracker_2) or the modern [FastTracker 2 Clone](https://github.com/8bitbubsy/ft2-clone)
+`*.669`   | [Composer 669](http://www.pouet.net/prod.php?which=63357) <!-- https://www.wikidata.org/wiki/Q9135198 -->
+
+Supported files using code from [STYMulator](http://atariarea.krap.pl/stymulator/):
+
+Extension | Notes
+:-------- | :----
+`*.YM`    | [Atari ST](https://en.wikipedia.org/wiki/Atari_ST#Technical_specifications) ([Yamaha YM2149](https://en.wikipedia.org/wiki/General_Instrument_AY-3-8910))
+
+Supported files using fork of [libsidplayfp](https://sourceforge.net/p/sidplay-residfp/wiki/Home/):
+
+Extension | Notes
+:-------- | :----
+`*.SID`, `*.RSID` | [C64](https://en.wikipedia.org/wiki/Commodore_64) ([SID 6581/8580](https://en.wikipedia.org/wiki/MOS_Technology_6581))
+
+Supported files using code from [aylet](http://www.svgalib.org/rus/aylet.html):
+
+Extension | Notes
+:-------- | :----
+`*.AY`    | [ZX Spectrum](https://en.wikipedia.org/wiki/ZX_Spectrum)/[Amstrad CPC](https://en.wikipedia.org/wiki/Amstrad_CPC) ([Yamaha YM2149](https://en.wikipedia.org/wiki/General_Instrument_AY-3-8910))
+
+Supported audio files (both compressed and PCM styled):
+
+Extension | Notes
+:-------- | :----
+`*.WAV`   |
+`*.OGG`   |
+`*.FLAC`  |
+`*.MP2`   |
+`*.MP3`   |
+`*.QOA`   | [Quite OK Audio](https://qoaformat.org/)
+
+Supported Audio-CD files:
+
+Extension | Notes
+:-------- | :----
+`*.CDA`   | Linux support only, using digital read out API.
+
+Supported files using fork of [TiMidity++](http://timidity.sourceforge.net/):
+
+Extension | Notes
+:-------- | :----
+`*.MID`   | [MIDI format](https://en.wikipedia.org/wiki/MIDI#General_MIDI)
+
+Supported files using [AdPlug](http://adplug.github.io/), for formats designed for the [OPL2](https://en.wikipedia.org/wiki/Yamaha_YM3812)/[OPL3](https://en.wikipedia.org/wiki/Yamaha_YMF262) AdLib sound chips:
+
+Extension | Notes
+:-------- | :----
+`*.HSC`   |
+`*.SNG`   |
+`*.D00`   |
+`*.ADL`   |
+`*.VGM`   |
+`*.RAD`   | [Reality AdLib Tracker](https://www.3eality.com/productions/reality-adlib-tracker)
+
+Supported files for [HivelyTracker](http://www.hivelytracker.co.uk/) tracked music, using code from the original tracker repository:
+
+Extension | Notes
+:-------- | :----
+`*.HVL`   | [Hively Tracker](https://github.com/pete-gordon/hivelytracker)
+`*.AHX`   | [AHX](http://amigascne.org/abyss/ahx/) or the not yet existing modern [AHX Clone](https://github.com/8bitbubsy/ahx-clone)
+
+Supported files using the [Game Music Emulator](https://bitbucket.org/mpyne/game-music-emu/wiki/Home) (various retro game consoles):
+
+Extension | Notes
+:-------- | :----
+`*.GBS`   | [GameBoy Sound System](https://en.wikipedia.org/wiki/Game_Boy_Sound_System)
+`*.GYM`   | [Genesis YM2612](https://vgmrips.net/wiki/GYM_File_Format)
+`*.HES`   | [Hudson Entertainment Sound](http://www.purose.net/befis/download/nezplug/hesspec.txt)
+`*.KSS`   | [Konami Sound System?](http://www.vgmpf.com/Wiki/index.php?title=KSS)
+`*.NSF`, `*.NSFe` | [Nintendo Sound Format](https://www.nesdev.org/wiki/NSF)
+`*.SAP`   | [Slight Atari Player](https://asap.sourceforge.net/sap-format.html)
+`*.SPC`   | [Super Nintendo / Super Famicom SPC-700 co-processor](http://vspcplay.raphnet.net/spc_file_format.txt)
+`*.VGM`, `*.VGZ` | [Video Game Music](https://vgmrips.net/wiki/VGM_File_Format)
+
+## Integrated support for modland.com
+
+Built into the file-browser is support for directly browsing <https://modland.com> utilizing `curl`.
+
+You need to initially fetch the database containing all the file names. This is available via `modland.com/setup.dev` inside the built-in file browser.
+
+## Manual Page
+
+Available in [Debian manpages](https://manpages.debian.org/testing/opencubicplayer/ocp.1.en.html).
+
+## Usage
+
+> [!NOTE]
+> If key letters are CAPITAL, press them with <kbd>shift</kbd>.
+
+Keys | Description
+:--- | :----------
+<kbd>esc</kbd><kbd>esc</kbd> | Eexit the program.
+<kbd>alt</kbd> + <kbd>k</kbd> | List available key shortcuts in the current view.
+
+### While playing
+
+Keys | Description
+:--- | :----------
+<kbd>Enter</kbd> | Next file from the playlist, if playlist is empty it opens the file-browser.
+<kbd>f</kbd> | File-browser.
+<kbd><</kbd> | Rewind.
+<kbd>></kbd> | Fast Forward.
+<kbd>a</kbd> | Text FFT analyzer, <kbd>A</kbd>: toggle FFT analyzer, <kbd>tab</kbd>: toggle colors.
+<kbd>b</kbd> | Phase viewer.
+<kbd>c</kbd> | Text Channel viewer.
+<kbd>d</kbd> | Start a shell (only works if using the console/curses version).
+<kbd>s</kbd> | Un/Silence channel.
+<kbd>q</kbd> | Un/Quiet other channels (solo/unsolo).
+<kbd>t</kbd> | Text Track viewer.
+<kbd>g</kbd> | Lo-Res FFT analyzer + history, <kbd>G</kbd>: high-Res FFT analyzer + history.
+<kbd>o</kbd> | Oscilloscope.
+<kbd>v</kbd> | Peak power level.
+<kbd>w</kbd> | Würfel mode (requires animation files to be present).
+<kbd>m</kbd> | Volume control.
+<kbd>n</kbd> | Note dots.
+<kbd>x</kbd> / <kbd>alt</kbd> + <kbd>x</kbd> | Extended mode / normal mode toggle.
+<kbd>'</kbd> | Link view.
+<kbd>,</kbd> / <kbd>.</kbd> | Fine panning.
+<kbd>+</kbd> / <kbd>-</kbd> | Fine volume.
+<kbd>*</kbd> / <kbd>/</kbd> | Fine balance.
+<kbd>Backspace</kbd> | Toggle filter.
+<kbd>f1</kbd> / <kbd>?</kbd> / <kbd>h</kbd> | Online Help.
+<kbd>f2</kbd> | Lower Volume.
+<kbd>f3</kbd> | Increase Volume.
+<kbd>f4</kbd> | Toggle Surround.
+<kbd>f5</kbd> | Panning left.
+<kbd>f6</kbd> | Panning right.
+<kbd>f7</kbd> | Balance left.
+<kbd>f8</kbd> | Balance right.
+<kbd>f9</kbd> | Decrease playback speed.
+<kbd>f10</kbd> | Increase playback speed.
+<kbd>\\</kbd> | Toggle pitch/speed lock (if file format makes this possible).
+<kbd>f11</kbd> | Decrease playback pitch.
+<kbd>f12</kbd> | Increase playback pitch.
+
+### File browser
+
+Keys | Description
+:--- | :----------
+<kbd>alt</kbd> + <kbd>e</kbd> | Edit meta-information.
+<kbd>alt</kbd> + <kbd>i</kbd> | Toggle file-list columns (long filename, title, etc).
+<kbd>alt</kbd> + <kbd>c</kbd> | Open system options list.
+<kbd>Insert</kbd> | Add to playlist.
+<kbd>Delete</kbd> | Remove from playlist.
+<kbd>Tab</kbd> | Move cursor between filelist and playlist.
+
+## Installing binaries on Linux
+
+See: <https://repology.org/project/ocp-open-cubic-player/versions>
+
+## Unifont.ttf?
 
 When you compile/install and have enabled X11/SDL/SDL2 support, the unifont TTF files are needed. This is a 8x16 font that has a main goal of being UTF-8/Unicode complete.
+
 For special scripts it will look incorrect, but the character-set should be complete.
 
-In most systems this font will be installed in */usr/share/fonts/truetype/unifont/* or */usr/share/fonts/opentype/unifont/* . If this path is different for your system, you can provide the correct path with *./configure --with-unifontdir-ttf=/your/path* and/or *./configure --with-unifontdir-otf=/your/path* .
+In most systems this font will be installed in `/usr/share/fonts/truetype/unifont/` or `/usr/share/fonts/opentype/unifont/`. If this path is different for your system, you can provide the correct path with `./configure --with-unifontdir-ttf=/your/path` and/or `./configure --with-unifontdir-otf=/your/path`.
 
-If the font-files on your system is not named exactly "unifont.ttf", "unifont\_csur.ttf" and "unifont\_upper.ttf", you can instruct alternative filenames using *./configure --with-unifont-ttf=/your/path/UniFont.ttf --with-unifont-csur-ttf=/your/path/UniFont-CSUR.ttf --with-unifont-upper-ttf=/your/path/UniFont-Upper.ttf"* . Same for opentype version of the files by using --with-unifont-otf --with-unifont-csur-otf and --with-unifont-upper-otf .
+If the font-files on your system is not named exactly `unifont.ttf`, `unifont_csur.ttf` and `unifont_upper.ttf`, you can configure alternative filenames using `./configure --with-unifont-ttf=/your/path/UniFont.ttf --with-unifont-csur-ttf=/your/path/UniFont-CSUR.ttf --with-unifont-upper-ttf=/your/path/UniFont-Upper.ttf`. Same for opentype version of the files by using `--with-unifont-otf`, `--with-unifont-csur-otf` and `--with-unifont-upper-otf`.
+
 If the filenames on your system contains version numbers, we ask you to fill a bug-report to your system provider and ask them to add symlinks without version numbers in them.
 
-# Installing on macOS
+## Installing on macOS
 
-`brew install ocp`
+Use: `brew install ocp`
 
-### more notes about Darwin
+### Additional notes for Darwin
 
-If you use liboss, you might need to edit `/opt/local/lib/pkgconfig/liboss.pc` and remove `-Wno-precomp` (liboss 0.0.1 is known to be broken and crashes, so we discourage the use of liboss)
+If you use liboss, you might need to edit `/opt/local/lib/pkgconfig/liboss.pc` and remove `-Wno-precomp` (liboss 0.0.1 is known to be broken and crashes, so we discourage the use of liboss).
 
 To configure Darwin, my experience is that you need to run configure like this:
-
-`PATH=$PATH:/opt/local/bin LDFLAGS=-L/opt/local/lib CFLAGS=-I/opt/local/include CXXFLAGS=-I/opt/local/include CPPFLAGS=-I/opt/local/include CPPCXXFLAGS=-I/opt/local/include ./configure`
+```
+PATH=$PATH:/opt/local/bin LDFLAGS=-L/opt/local/lib CFLAGS=-I/opt/local/include CXXFLAGS=-I/opt/local/include CPPFLAGS=-I/opt/local/include CPPCXXFLAGS=-I/opt/local/include ./configure
+```
 
 and optionally add things like `--prefix` etc.
 
-To get curses up and running with colors, you need to run ocp like this
+To get curses up and running with colors, you need to run ocp like this:
+```
+TERM=xterm-color ocp-curses
+```
 
-`TERM=xterm-color ocp-curses`
-
-# Docker images
+## Docker Images
 
 Files for building Docker images for Open Cubic Player are available in [this repository](https://github.com/hhromic/opencubicplayer-docker).
 
@@ -218,21 +214,18 @@ Ready to use images can be pulled directly from the GitHub Container Registry of
 
 Refer to the [README file](https://github.com/hhromic/opencubicplayer-docker?tab=readme-ov-file#readme) for usage information and more details.
 
-# Sample sources of where to find music
+## Sample sources of where to find music
 
-https://modarchive.org/
+* <https://modarchive.org/>
+* <http://www.chiptune.com/>
+* <http://www.keygenmusic.net/>
+* <https://ftp.hornet.org/pub/demos/music/contests/>
+* <https://modland.com/pub/modules/>
 
-http://www.chiptune.com/
+## IRC
 
-http://www.keygenmusic.net/
+Available at <https://libera.chat> in `#ocp`.
 
-https://ftp.hornet.org/pub/demos/music/contests/
-
-https://modland.com/pub/modules/
-
-# IRC
-https://libera.chat in #ocp
-
-# Packaging status
+## Packaging Status
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/ocp-open-cubic-player.svg)](https://repology.org/project/ocp-open-cubic-player/versions)

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Extension | Notes
 
 Built into the file-browser is support for directly browsing <https://modland.com> utilizing `curl`.
 
-You need to initially fetch the database containing all the file names. This is available via `modland.com/setup.dev` inside the built-in file browser.
+An initial fetch of the database containing all the file names is required for this feature to work.
+This is available in the `modland.com/setup.dev` option inside of the built-in file browser.
 
 ## Manual Page
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Supported files using fork of [TiMidity++](http://timidity.sourceforge.net/):
 
 Extension | Notes
 :-------- | :----
-`*.MID`   | [MIDI format](https://en.wikipedia.org/wiki/MIDI#General_MIDI)
+`*.MID`   | [General MIDI](https://en.wikipedia.org/wiki/MIDI#General_MIDI)
 
 Supported files using [AdPlug](http://adplug.github.io/), for formats designed for the [OPL2](https://en.wikipedia.org/wiki/Yamaha_YM3812)/[OPL3](https://en.wikipedia.org/wiki/Yamaha_YMF262) AdLib sound chips:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Cubic Player
 
-Unix port of [Open Cubic Player](https://www.cubic.org/player/), which is a text-based player with some few graphical views. Visual output can be done through nCurses, Linux console (VCSA + FrameBuffer), X11 or SDL/SDL2. It can be compiled on various different Unix-based operating systems.
+Unix port of [Open Cubic Player](https://www.cubic.org/player/), which is a text-based player with some few graphical views. Visual output can be done through nCurses, Linux console (VCSA + FrameBuffer), X11 or SDL. It can be compiled on various different Unix-based operating systems.
 
 ![Screenshot](doc/screenshot-01.png)
 
@@ -60,6 +60,8 @@ Supported Audio-CD files:
 Extension | Notes
 :-------- | :----
 `*.CDA`   | Linux support only, using digital read out API.
+`*.CUE`   | [Cue sheet metadata](https://en.wikipedia.org/wiki/Cue_sheet_(computing))
+`*.TOC`   | [CD recorder disc-at-once (cdrdao)](https://en.wikipedia.org/wiki/Cdrdao)
 
 Supported files using fork of [TiMidity++](http://timidity.sourceforge.net/):
 
@@ -115,7 +117,7 @@ Available in [Debian manpages](https://manpages.debian.org/testing/opencubicplay
 
 Keys | Description
 :--- | :----------
-<kbd>esc</kbd><kbd>esc</kbd> | Eexit the program.
+<kbd>esc</kbd><kbd>esc</kbd> | Exit the program.
 <kbd>alt</kbd> + <kbd>k</kbd> | List available key shortcuts in the current view.
 
 ### While playing
@@ -176,7 +178,7 @@ See: <https://repology.org/project/ocp-open-cubic-player/versions>
 
 ## Unifont.ttf?
 
-When you compile/install and have enabled X11/SDL/SDL2 support, the unifont TTF files are needed. This is a 8x16 font that has a main goal of being UTF-8/Unicode complete.
+When you compile/install and have enabled X11/SDL support, the unifont TTF files are needed. This is a 8x16 font that has a main goal of being UTF-8/Unicode complete.
 
 For special scripts it will look incorrect, but the character-set should be complete.
 
@@ -219,7 +221,7 @@ Refer to the [README file](https://github.com/hhromic/opencubicplayer-docker?tab
 * <https://modarchive.org/>
 * <http://www.chiptune.com/>
 * <http://www.keygenmusic.net/>
-* <https://ftp.hornet.org/pub/demos/music/contests/>
+* <https://hornet.org/music/>
 * <https://modland.com/pub/modules/>
 
 ## IRC

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Open Cubic Player
 
-Unix port of [Open Cubic Player](https://www.cubic.org/player/), which is a text-based player with some few graphical views. Visual output can be done through nCurses, Linux console (VCSA + FrameBuffer), X11 or SDL. It can be compiled on various different Unix-based operating systems.
+Unix port of [Open Cubic Player](https://www.cubic.org/player/), which is a text-based player with some few graphical views.
+Visual output can be done through nCurses, Linux console (VCSA + FrameBuffer), X11 or SDL.
+This port can be compiled for various different Unix-based operating systems, including MinGW compilers.
 
 ![Screenshot](doc/screenshot-01.png)
 


### PR DESCRIPTION
This PR adds information about Docker images and I also took the opportunity to revamp a bit the README file to use tables and improved heading levels for an easier-to-read and more organized document.

I made the two changes in independent commits.
If you don't like the revamping, I can simply drop the second commit and only keep the Docker information alone.

If you want to quickly see how it looks:
https://github.com/hhromic/opencubicplayer/tree/readme-update?tab=readme-ov-file#readme

Closes #68 