### PR TITLE
[configure] allow to enable/disable x11 SHM extension API

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -292,6 +292,8 @@ int strverscmp(const char *s1, const char *s2);
 
 #undef HAVE_X11
 
+#undef HAVE_X11_SHM
+
 #undef HAVE_SDL
 
 #undef HAVE_SDL2

--- a/configure
+++ b/configure
@@ -737,6 +737,7 @@ SDL2_CFLAGS
 HAVE_SDL3
 SDL3_LIBS
 SDL3_CFLAGS
+HAVE_X11_SHM
 HAVE_X11
 HAVE_FLAC
 FLAC_LIBS
@@ -856,6 +857,7 @@ enable_option_checking
 with_debug
 with_builtin
 with_x11
+with_x11_shm
 with_mad
 with_libgme
 with_alsa
@@ -1589,6 +1591,7 @@ Optional Packages:
                           playback plugins, audio mixers and audio drivers are
                           always modules
   --with-x11              force/disable x11 support
+  --with-x11-shm          force/disable x11 SHM support
   --with-mad              force/disable mad mpeg audio support
   --with-libgme           force/disable libgme (Game Music Emulator support)
   --with-alsa             force/disable alsa support
@@ -8047,6 +8050,16 @@ else case e in #(
 esac
 fi
 
+
+# Check whether --with-x11_shm was given.
+if test ${with_x11_shm+y}
+then :
+  withval=$with_x11_shm;
+else case e in #(
+  e) with_x11_shm=auto ;;
+esac
+fi
+
 #AC_ARG_WITH([adplug],                 [AS_HELP_STRING([--with-adplug],                    [force/disable adplug support])],                                                [], [with_adplug=auto])
 
 # Check whether --with-mad was given.
@@ -12195,7 +12208,7 @@ fi
 
 fi
 
-if test "x$with_x11" != "xno"
+if test "x$with_x11" != "xno" && test "x$with_x11_shm" != "xno"
 then :
 
 	ac_fn_c_check_header_compile "$LINENO" "X11/extensions/XShm.h" "ac_cv_header_X11_extensions_XShm_h" "#include <X11/Xlib.h>
@@ -12205,11 +12218,11 @@ if test "x$ac_cv_header_X11_extensions_XShm_h" = xyes
 then :
 
 else case e in #(
-  e)  if test "x$with_x11" = "xyes"
+  e)  if test "x$with_x11_shm" = "xyes"
 then :
   as_fn_error $? "\"XShm header files was not found\"" "$LINENO" 5
 else case e in #(
-  e) with_x11="no" ;;
+  e) with_x11_shm="no" ;;
 esac
 fi  ;;
 esac
@@ -12305,7 +12318,7 @@ fi
 
 fi
 
-if test "x$with_x11" != "xno"
+if test "x$with_x11" != "xno" && test "x$with_x11_shm" != "xno"
 then :
 
 	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for XShmQueryExtension in -lXext" >&5
@@ -12355,11 +12368,11 @@ if test "x$ac_cv_lib_Xext_XShmQueryExtension" = xyes
 then :
   X11_LIBS="-lXext $X11_LIBS"
 else case e in #(
-  e)  if test "x$with_x11" = "xyes"
+  e)  if test "x$with_x11_shm" = "xyes"
 then :
   as_fn_error $? "\"SHM/X11 not found (expected to be found in /usr/X11R6/lib)\"" "$LINENO" 5
 else case e in #(
-  e) with_x11="no" ;;
+  e) with_x11_shm="no" ;;
 esac
 fi  ;;
 esac
@@ -12433,6 +12446,7 @@ fi
 
 fi
 
+
 if test "x$with_x11" = "xno"
 then :
 
@@ -12444,6 +12458,19 @@ else case e in #(
 	HAVE_X11=1
 	printf "%s\n" "#define HAVE_X11 1" >>confdefs.h
 
+	if test "x$with_x11_shm" = "xno"
+then :
+
+		HAVE_X11_SHM=
+
+else case e in #(
+  e)
+		HAVE_X11_SHM=1
+		printf "%s\n" "#define HAVE_X11_SHM 1" >>confdefs.h
+
+	 ;;
+esac
+fi
  ;;
 esac
 fi
@@ -23082,6 +23109,13 @@ then :
   echo "x11:               OFF"
 else case e in #(
   e) echo "x11:               ON" ;;
+esac
+fi
+if test "x$with_x11_shm"   = "xno"
+then :
+  echo "x11 SHM:           OFF"
+else case e in #(
+  e) echo "x11 SHM:           ON" ;;
 esac
 fi
 if test "x$with_sdl"       = "xno"

--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,7 @@ AC_DEFINE_UNQUOTED(LIB_SUFFIX, "$LIB_SUFFIX")
 AC_ARG_WITH([builtin],                 [AS_HELP_STRING([--with-builtin=core,auto,none],    [force/disable builtin plugins support. For now playback plugins, audio mixers and audio drivers are always modules])],
                                                                                                                                                                             [], [with_builtin=auto])
 AC_ARG_WITH([x11],                     [AS_HELP_STRING([--with-x11],                       [force/disable x11 support])],                                                   [], [with_x11=auto])
+AC_ARG_WITH([x11_shm],                 [AS_HELP_STRING([--with-x11-shm],                   [force/disable x11 SHM support])],                                               [], [with_x11_shm=auto])
 #AC_ARG_WITH([adplug],                 [AS_HELP_STRING([--with-adplug],                    [force/disable adplug support])],                                                [], [with_adplug=auto])
 AC_ARG_WITH([mad],                     [AS_HELP_STRING([--with-mad],                       [force/disable mad mpeg audio support])],                                        [], [with_mad=auto])
 AC_ARG_WITH([libgme],                  [AS_HELP_STRING([--with-libgme],                    [force/disable libgme (Game Music Emulator support)])],                          [], [with_libgme=auto])
@@ -502,8 +503,8 @@ AS_IF([test "x$with_x11" != "xno"], [
 ])
 ])
 
-AS_IF([test "x$with_x11" != "xno"], [
-	AC_CHECK_HEADER([X11/extensions/XShm.h], [], [ AS_IF([test "x$with_x11" = "xyes"], [AC_MSG_ERROR("XShm header files was not found")], [with_x11="no"]) ],
+AS_IF([test "x$with_x11" != "xno" && test "x$with_x11_shm" != "xno"], [
+	AC_CHECK_HEADER([X11/extensions/XShm.h], [], [ AS_IF([test "x$with_x11_shm" = "xyes"], [AC_MSG_ERROR("XShm header files was not found")], [with_x11_shm="no"]) ],
 [#include <X11/Xlib.h>
 ])
 ])
@@ -519,8 +520,8 @@ AS_IF([test "x$with_x11" != "xno"], [
 	LIBS=$push_LIBS
 ])
 
-AS_IF([test "x$with_x11" != "xno"], [
-	AC_CHECK_LIB([Xext], [XShmQueryExtension], [X11_LIBS="-lXext $X11_LIBS"], [ AS_IF([test "x$with_x11" = "xyes"], [AC_MSG_ERROR(["SHM/X11 not found (expected to be found in /usr/X11R6/lib)"])], [with_x11="no"]) ], [-lX11 -lXext -L/usr/X11R6/lib])
+AS_IF([test "x$with_x11" != "xno" && test "x$with_x11_shm" != "xno"], [
+	AC_CHECK_LIB([Xext], [XShmQueryExtension], [X11_LIBS="-lXext $X11_LIBS"], [ AS_IF([test "x$with_x11_shm" = "xyes"], [AC_MSG_ERROR(["SHM/X11 not found (expected to be found in /usr/X11R6/lib)"])], [with_x11_shm="no"]) ], [-lX11 -lXext -L/usr/X11R6/lib])
 	LIBS=$push_LIBS
 ])
 
@@ -529,12 +530,19 @@ AS_IF([test "x$with_x11" != "xno"], [
 	LIBS=$push_LIBS
 ])
 AC_SUBST(HAVE_X11)
+AC_SUBST(HAVE_X11_SHM)
 AS_IF([test "x$with_x11" = "xno"], [
 	X11_LIBS=
 	HAVE_X11=
 ],[
 	HAVE_X11=1
 	AC_DEFINE(HAVE_X11)
+	AS_IF([test "x$with_x11_shm" = "xno"], [
+		HAVE_X11_SHM=
+	],[
+		HAVE_X11_SHM=1
+		AC_DEFINE(HAVE_X11_SHM)
+	])
 ])
 
 AS_IF([test "x$with_sdl" = "xyes" && test "x$with_sdl2" = "xyes"], [AC_MSG_ERROR("Can not use both --with-sdl and --with-sdl2")])
@@ -1246,6 +1254,7 @@ AS_IF([test "x$with_mad"       = "xno" ], [echo "mad:               OFF"], [echo
 AS_IF([test "x$with_flac"      = "xno" ], [echo "FLAC:              OFF"], [echo "FLAC:              ON"])
 AS_IF([test "x$with_libgme"    = "xno" ], [echo "GME:               OFF"], [echo "GME:               ON"])
 AS_IF([test "x$with_x11"       = "xno" ], [echo "x11:               OFF"], [echo "x11:               ON"])
+AS_IF([test "x$with_x11_shm"   = "xno" ], [echo "x11 SHM:           OFF"], [echo "x11 SHM:           ON"])
 AS_IF([test "x$with_sdl"       = "xno" ], [echo "SDL:               OFF"], [echo "SDL:               ON"])
 AS_IF([test "x$with_sdl2"      = "xno" ], [echo "SDL2:              OFF"], [echo "SDL2:              ON"])
 AS_IF([test "x$with_sdl3"      = "xno" ], [echo "SDL3:              OFF"], [echo "SDL3:              ON"])

--- a/stuff/poutput-x11.c
+++ b/stuff/poutput-x11.c
@@ -23,8 +23,6 @@
  *    -first release
  */
 
-#define ENABLE_SHM 1 /* makes it possible to disable XShmImage API, to test the classic non-shm path */
-
 #define _CONSOLE_DRIVER
 #include "config.h"
 #include <ctype.h>
@@ -37,11 +35,11 @@
 #include <X11/xpm.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/xf86vmode.h>
-#ifdef ENABLE_SHM
+#ifdef HAVE_X11_SHM
 #include <X11/extensions/XShm.h>
 #endif
 #include <sys/ipc.h>
-#ifdef ENABLE_SHM
+#ifdef HAVE_X11_SHM
 #include <sys/shm.h>
 #endif
 #include <stdio.h>
@@ -157,7 +155,7 @@ static Atom WM_DELETE_WINDOW;
 static int we_have_fullscreen;
 static int do_fullscreen=0;
 
-#ifdef ENABLE_SHM
+#ifdef HAVE_X11_SHM
 static XShmSegmentInfo shminfo[1];
 static int shm_completiontype = -1;
 #endif
@@ -791,7 +789,7 @@ static void x11_common_event_loop(void)
 
 		XNextEvent(mDisplay, &event);
 
-#ifdef ENABLE_SHM
+#ifdef HAVE_X11_SHM
 		if (event.type==shm_completiontype)
 			continue;
 #endif
@@ -1191,7 +1189,7 @@ static void create_window(void)
 
 static void create_image(void)
 {
-#ifdef ENABLE_SHM
+#ifdef HAVE_X11_SHM
 	if (mLocalDisplay && XShmQueryExtension(mDisplay) )
 	{
 		if (image)
@@ -1300,7 +1298,7 @@ static void create_image(void)
 
 static void destroy_image(void)
 {
-#ifdef ENABLE_SHM
+#ifdef HAVE_X11_SHM
 	if (shm_completiontype>=0)
 	{
 		if (image)
@@ -1909,7 +1907,7 @@ static void RefreshScreenGraph(void)
 		}
 	}
 
-#ifdef ENABLE_SHM
+#ifdef HAVE_X11_SHM
 	if (shm_completiontype>=0)
 		XShmPutImage(mDisplay, window, copyGC, image, 0, 0, 0, (Console.GraphLines == 240 ? 20 : 0), Console.GraphBytesPerLine, Console.GraphLines, True);
 	else


### PR DESCRIPTION
This PR implements configurable x11 SHM extension API support in the x11 driver.
Some environments such as Docker containers do not support SHM due to isolation.
Disabling this API allows the x11 driver to work in these cases at the expense of performance.

At the moment, Docker containers can use the SDL2/3 driver, which automatically disable SHM if not available.
With this PR, Open Cubic Player can be used in Docker containers with the native x11 driver without forcing SHM.

Note: I'm far from an expert in autotools. It took me a while to figure out how to implement this correctly.
Please let me know of any improvements from your (much larger) experience with autotools.